### PR TITLE
Issue #52: Segfault on unsupported characters.

### DIFF
--- a/damerau_levenshtein.c
+++ b/damerau_levenshtein.c
@@ -68,7 +68,13 @@ int damerau_levenshtein_distance(const JFISH_UNICODE *s1, const JFISH_UNICODE *s
             dist[((i+1)*cols) + j + 1] = MIN(MIN(d1, d2), MIN(d3, d4));
         }
 
-        da[(JFISH_UNICODE)s1[i-1]] = i;
+        da_idx = (JFISH_UNICODE)s1[i-1];
+        if (da_idx >= len_da) {
+            free(dist);
+            free(da);
+            return -2;
+        }
+        da[da_idx] = i;
     }
 
     result = dist[((len1+1) * cols) + len2 + 1];

--- a/damerau_levenshtein.c
+++ b/damerau_levenshtein.c
@@ -12,11 +12,13 @@ int damerau_levenshtein_distance(const JFISH_UNICODE *s1, const JFISH_UNICODE *s
     size_t i, j, i1, j1;
     size_t db;
     size_t d1, d2, d3, d4, result;
+    size_t da_idx;
     unsigned short cost;
 
     size_t *dist = NULL;
 
-    size_t *da = calloc(256, sizeof(size_t));
+    size_t len_da = 256;
+    size_t *da = calloc(len_da, sizeof(size_t));
     if (!da) {
         return -1;
     }
@@ -42,7 +44,13 @@ int damerau_levenshtein_distance(const JFISH_UNICODE *s1, const JFISH_UNICODE *s
     for (i = 1; i <= len1; i++) {
         db = 0;
         for (j = 1; j <= len2; j++) {
-            i1 = da[(JFISH_UNICODE)s2[j-1]];
+            da_idx = (JFISH_UNICODE)s2[j-1];
+            if (da_idx >= len_da) {
+                free(dist);
+                free(da);
+                return -2;
+            }
+            i1 = da[da_idx];
             j1 = db;
 
             if (s1[i - 1] == s2[j - 1]) {

--- a/jellyfishmodule.c
+++ b/jellyfishmodule.c
@@ -27,6 +27,8 @@ static struct jellyfish_state _state;
 #define NO_BYTES_ERR_STR "expected unicode, got str"
 #endif
 
+#define UNSUPPORTED_CODEPOINT "Encountered unsupported code point in string."
+
 
 /* Returns a new reference to a PyString (python < 3) or
  * PyBytes (python >= 3.0).
@@ -156,6 +158,10 @@ static PyObject* jellyfish_damerau_levenshtein_distance(PyObject *self,
     result = damerau_levenshtein_distance(s1, s2, len1, len2);
     if (result == -1) {
         PyErr_NoMemory();
+        return NULL;
+    }
+    else if (result == -2) {
+        PyErr_SetString(PyExc_TypeError, UNSUPPORTED_CODEPOINT);
         return NULL;
     }
 


### PR DESCRIPTION
These changes cause jellyfish_damerau_levenshtein_distance to raise a TypeError instead of segfaulting when it encounters a codepoint above 255. This does cause a divergence from the behavior of the pure python version of the library, which returns the correct value.

To test it, I added the following line to damerau_levenshhtein.csv in the main Jellyfish project:
"myoutdoorworld","нахлыст",14