### PR TITLE
Fix segmentation fault on two empty strings

### DIFF
--- a/mra.c
+++ b/mra.c
@@ -28,6 +28,10 @@ int match_rating_comparison(const JFISH_UNICODE *s1, size_t len1, const JFISH_UN
     i = s1c_len - 1;
     j = s2c_len - 1;
 
+    if (s1c_len == 0 && s2c_len == 0) {
+        return -1;
+    }
+
     while (i != 0 && j != 0) {
         if (s1_codex[i] == ' ') {
             i--;


### PR DESCRIPTION
Fix for https://github.com/jamesturk/jellyfish/issues/73

```
>>> import jellyfish.cjellyfish as cjellyfish
>>> cjellyfish.match_rating_comparison('', '')
None
```

