### PR TITLE
Bugfix for incorrect soundex codes like Ashcroft

### DIFF
--- a/jellyfish.h
+++ b/jellyfish.h
@@ -23,7 +23,7 @@ int levenshtein_distance(const JFISH_UNICODE *str1, int len1, const JFISH_UNICOD
 int damerau_levenshtein_distance(const JFISH_UNICODE *str1, const JFISH_UNICODE *str2,
         size_t len1, size_t len2);
 
-char* soundex(const char *str);
+char* soundex(const char *str, size_t len);
 
 char* metaphone(const char *str);
 

--- a/jellyfishmodule.c
+++ b/jellyfishmodule.c
@@ -181,7 +181,7 @@ static PyObject* jellyfish_soundex(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    result = soundex(UTF8_BYTES(normalized));
+    result = soundex(UTF8_BYTES(normalized), len);
     Py_DECREF(normalized);
 
     if (!result) {

--- a/soundex.c
+++ b/soundex.c
@@ -2,11 +2,132 @@
 #include <ctype.h>
 #include <stdlib.h>
 
-char* soundex(const char *str)
+// This implementation is based on the soundex implemenation in the R
+// stringdist package (https://github.com/markvanderloo/stringdist/blob/master
+// /pkg/src/soundex.c). Stringdist is distributed with the GPL3 license. See
+// https://github.com/markvanderloo/stringdist for the complete license. 
+
+
+// Translate similar sounding consonants to numeric codes; vowels are all 
+// translated to 'a' and voiceless characters (and other characters) are 
+// translated to 'h'.
+// Upper and lower case ASCII characters are treated as separate cases,
+// avoiding the use of 'tolower' whose effect depends on locale.
+static unsigned int translate_soundex(char c) {
+  switch ( c ) {
+    case 'b':
+    case 'f':
+    case 'p':
+    case 'v':
+    case 'B':
+    case 'F':
+    case 'P':
+    case 'V':
+      return '1';
+    case 'c':
+    case 'g':
+    case 'j':
+    case 'k':
+    case 'q':
+    case 's':
+    case 'x':
+    case 'z':
+    case 'C':
+    case 'G':
+    case 'J':
+    case 'K':
+    case 'Q':
+    case 'S':
+    case 'X':
+    case 'Z':
+      return '2';
+    case 'd':
+    case 't':
+    case 'D':
+    case 'T':
+      return '3';
+    case 'l':
+    case 'L':
+      return '4';
+    case 'm':
+    case 'n':
+    case 'M':
+    case 'N':
+      return '5';
+    case 'r':
+    case 'R':
+      return '6';
+    case 'h':
+    case 'w':
+    case 'H':
+    case 'W':
+      return 'h';
+    case 'a':
+    case 'e':
+    case 'i':
+    case 'o':
+    case 'u':
+    case 'y':
+    case 'A':
+    case 'E':
+    case 'I':
+    case 'O':
+    case 'U':
+    case 'Y':
+      return 'a'; // use 'a' to encode vowels
+    case '!': // we will allow all printable ASCII characters.
+    case '"':
+    case '#':
+    case '$':
+    case '%':
+    case '&':
+    case '\'':
+    case '(':
+    case ')':
+    case '*':
+    case '+':
+    case ',':
+    case '-':
+    case '.':
+    case '/':
+    case ':':
+    case ';':
+    case '<':
+    case '=':
+    case '>':
+    case '?':
+    case '@':
+    case '[':
+    case '\\':
+    case ']':
+    case '^':
+    case '_':
+    case '`':
+    case '{':
+    case '|':
+    case '}':
+    case '~':
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+    case ' ':
+      return 'h'; // ignored characters; voiceless symbols.
+    default:
+      return '?'; // other characters are ignored with a warning
+  }
+}
+
+
+char* soundex(const char *str, size_t str_len)
 {
-    const char *s;
-    char c, prev;
-    int i;
+    unsigned int i = 0, j = 0;
     char *result = calloc(5, sizeof(char));
 
     if (!result) {
@@ -17,54 +138,35 @@ char* soundex(const char *str)
         return result;
     }
 
-    prev = '\0';
-    for(s = str, i = 1; *s && i < 4; s++) {
-        switch(tolower(*s)) {
-        case 'b':
-        case 'f':
-        case 'p':
-        case 'v':
-            c = '1';
-            break;
-        case 'c':
-        case 'g':
-        case 'j':
-        case 'k':
-        case 'q':
-        case 's':
-        case 'x':
-        case 'z':
-            c = '2';
-            break;
-        case 'd':
-        case 't':
-            c = '3';
-            break;
-        case 'l':
-            c = '4';
-            break;
-        case 'm':
-        case 'n':
-            c = '5';
-            break;
-        case 'r':
-            c = '6';
-            break;
-        default:
-            c = '\0';
-        }
-
-        if (c && c != prev && s != str) {
-            result[i++] = c;
-        }
-        prev = c;
+    unsigned int cj = translate_soundex(str[0]);
+    // the first character is copied directly and not translated to a numerical
+    // code
+    if ( cj == '?' ){
+        // the translated character is non-printable ASCII or non-ASCII.
+        result[0] = str[0];
+    } else {
+        result[0] = toupper(str[0]);
     }
 
-    for ( ; i < 4; i++) {
-        result[i] = '0';
+    for (i = 1; i < str_len && j < 3; ++i) {
+
+        unsigned int ci = translate_soundex(str[i]);
+        if (ci == 'a') {
+            // vowels are not added to the result; but we do set the previous
+            // character to the vower because two consonants with a vowel in between
+            // are not merged
+            cj = ci;
+        } else if (ci != 'h') {
+            // a consonant that is not equal to the previous consonant is added to 
+            // the result
+            if (ci != cj) {
+                result[++j] = ci;
+                cj = ci;
+            }
+        }
     }
 
-    result[0] = toupper(*str);
+    for (++j ; j < 4; ++j) result[j] = '0';
 
     return result;
 }


### PR DESCRIPTION
Fix for jamesturk/jellyfish#83. Implementation based on https://github.com/markvanderloo/stringdist/blob/master/pkg/src/soundex.c. 

``` python
>>> from jellyfish.cjellyfish import soundex
>>> soundex('ashcroft')
'A261'
>>> soundex('ash')
'A200'
>>> soundex('jellyfish')
'J412'
```
