### PR TITLE
damerau_levenshtein_distance: add non-ASCII support

### DIFF
--- a/damerau_levenshtein.c
+++ b/damerau_levenshtein.c
@@ -67,6 +67,7 @@ size_t trie_get(struct trie* d, size_t key)
     size_t level_pos = 0;
 
     size_t cur_remainder = key;
+    size_t cur_key;
     while (1) {
         level_keys[level_pos] = cur_remainder % TRIE_VALUES_PER_LEVEL;
         cur_remainder /= TRIE_VALUES_PER_LEVEL;
@@ -76,7 +77,6 @@ size_t trie_get(struct trie* d, size_t key)
         ++level_pos;
     }
 
-    size_t cur_key;
     while (level_pos) {
         cur_key = level_keys[level_pos];
         if (!d->child_nodes || !d->child_nodes[cur_key]) {
@@ -98,6 +98,7 @@ int trie_set(struct trie* d, size_t key, size_t val)
     size_t level_pos = 0;
 
     size_t cur_remainder = key;
+    size_t cur_key;
     while (1) {
         level_keys[level_pos] = cur_remainder % TRIE_VALUES_PER_LEVEL;
         cur_remainder /= TRIE_VALUES_PER_LEVEL;
@@ -107,7 +108,6 @@ int trie_set(struct trie* d, size_t key, size_t val)
         ++level_pos;
     }
 
-    size_t cur_key;
     while (level_pos) {
         cur_key = level_keys[level_pos];
         if (!d->child_nodes) {

--- a/damerau_levenshtein.c
+++ b/damerau_levenshtein.c
@@ -38,7 +38,7 @@ struct trie {
 };
 
 
-struct trie* trie_create()
+struct trie* trie_create(void)
 {
     return calloc(1, sizeof(struct trie));
 }
@@ -46,12 +46,13 @@ struct trie* trie_create()
 
 void trie_destroy(struct trie* d)
 {
+    size_t i;
     if (!d) {
         return;
     }
     free(d->values);
     if (d->child_nodes) {
-        for (size_t i = 0; i < TRIE_VALUES_PER_LEVEL; ++i) {
+        for (i = 0; i < TRIE_VALUES_PER_LEVEL; ++i) {
             trie_destroy(d->child_nodes[i]);
         }
     }

--- a/damerau_levenshtein.c
+++ b/damerau_levenshtein.c
@@ -28,9 +28,9 @@
 */
 
 
-static const size_t TRIE_VALUES_PER_LEVEL = 256;
+#define TRIE_VALUES_PER_LEVEL 256
 /* Each level takes one byte from dictionary key, hence max levels is: */
-static const size_t TRIE_MAX_LEVELS = sizeof(size_t);
+#define TRIE_MAX_LEVELS sizeof(size_t)
 
 struct trie {
     size_t* values;

--- a/damerau_levenshtein.c
+++ b/damerau_levenshtein.c
@@ -3,6 +3,138 @@
 #include <stdio.h>
 #include <wchar.h>
 
+/*
+
+  Trie is a nested search tree, where each node's key is broken down into parts
+  and looking up a certain key means a sequence of lookups in small associative
+  arrays. They are usually used for strings, where a word "foo" would be
+  basically looked up as trie["f"]["o"]["o"].
+
+  In this case, the tries split the incoming integer into segments, omitting
+  upper zero ones, and they are looked up as follows:
+
+  I.e. for segments of 1 byte,
+
+  - for key = 0x11, the result is d->values[0x11]
+  - for key = 0x1122  -  d->child_nodes[0x11]->values[0x22]
+  - for key = 0x112233  -  d->child_nodes[0x11]->child_nodes[0x22]->values[0x33]
+
+  And so on.
+
+  Child nodes are created on demand, when a value should be stored in them.
+
+  If no value is stored in the trie for a certain key, the lookup returns 0.
+
+*/
+
+
+static const size_t TRIE_VALUES_PER_LEVEL = 256;
+/* Each level takes one byte from dictionary key, hence max levels is: */
+static const size_t TRIE_MAX_LEVELS = sizeof(size_t);
+
+struct trie {
+    size_t* values;
+    struct trie** child_nodes;
+};
+
+
+struct trie* trie_create()
+{
+    return calloc(1, sizeof(struct trie));
+}
+
+
+void trie_destroy(struct trie* d)
+{
+    if (!d) {
+        return;
+    }
+    free(d->values);
+    if (d->child_nodes) {
+        for (size_t i = 0; i < TRIE_VALUES_PER_LEVEL; ++i) {
+            trie_destroy(d->child_nodes[i]);
+        }
+    }
+    free(d->child_nodes);
+    free(d);
+}
+
+
+size_t trie_get(struct trie* d, size_t key)
+{
+    size_t level_keys[TRIE_MAX_LEVELS];
+    size_t level_pos = 0;
+
+    size_t cur_remainder = key;
+    while (1) {
+        level_keys[level_pos] = cur_remainder % TRIE_VALUES_PER_LEVEL;
+        cur_remainder /= TRIE_VALUES_PER_LEVEL;
+        if (!cur_remainder) {
+            break;
+        }
+        ++level_pos;
+    }
+
+    size_t cur_key;
+    while (level_pos) {
+        cur_key = level_keys[level_pos];
+        if (!d->child_nodes || !d->child_nodes[cur_key]) {
+            return 0;
+        }
+        d = d->child_nodes[cur_key];
+        --level_pos;
+    }
+    if (!d->values) {
+        return 0;
+    }
+    return d->values[level_keys[0]];
+}
+
+
+int trie_set(struct trie* d, size_t key, size_t val)
+{
+    size_t level_keys[TRIE_MAX_LEVELS];
+    size_t level_pos = 0;
+
+    size_t cur_remainder = key;
+    while (1) {
+        level_keys[level_pos] = cur_remainder % TRIE_VALUES_PER_LEVEL;
+        cur_remainder /= TRIE_VALUES_PER_LEVEL;
+        if (!cur_remainder) {
+            break;
+        }
+        ++level_pos;
+    }
+
+    size_t cur_key;
+    while (level_pos) {
+        cur_key = level_keys[level_pos];
+        if (!d->child_nodes) {
+            d->child_nodes = calloc(TRIE_VALUES_PER_LEVEL, sizeof(struct trie*));
+            if (!d->child_nodes) {
+                return 0;
+            }
+        }
+        if (!d->child_nodes[cur_key]) {
+            d->child_nodes[cur_key] = trie_create();
+            if (!d->child_nodes[cur_key]){
+                return 0;
+            }
+        }
+        d = d->child_nodes[cur_key];
+        --level_pos;
+    }
+
+    if (!d->values) {
+        d->values = calloc(TRIE_VALUES_PER_LEVEL, sizeof(size_t));
+        if (!d->values) {
+            return 0;
+        }
+    }
+    d->values[level_keys[0]] = val;
+    return 1;
+}
+
 
 int damerau_levenshtein_distance(const JFISH_UNICODE *s1, const JFISH_UNICODE *s2, size_t len1, size_t len2)
 {
@@ -12,21 +144,19 @@ int damerau_levenshtein_distance(const JFISH_UNICODE *s1, const JFISH_UNICODE *s
     size_t i, j, i1, j1;
     size_t db;
     size_t d1, d2, d3, d4, result;
-    size_t da_idx;
     unsigned short cost;
 
     size_t *dist = NULL;
 
-    const size_t len_da = 256;
-    size_t *da = calloc(len_da, sizeof(size_t));
+    struct trie* da = trie_create();
     if (!da) {
         return -1;
     }
 
     dist = malloc((len1 + 2) * cols * sizeof(size_t));
     if (!dist) {
-        free(da);
-        return -1;
+        result = -1;
+        goto cleanup_da;
     }
 
     dist[0] = infinite;
@@ -44,13 +174,7 @@ int damerau_levenshtein_distance(const JFISH_UNICODE *s1, const JFISH_UNICODE *s
     for (i = 1; i <= len1; i++) {
         db = 0;
         for (j = 1; j <= len2; j++) {
-            da_idx = (JFISH_UNICODE)s2[j-1];
-            if (da_idx >= len_da) {
-                free(dist);
-                free(da);
-                return -2;
-            }
-            i1 = da[da_idx];
+            i1 = trie_get(da, s2[j-1]);
             j1 = db;
 
             if (s1[i - 1] == s2[j - 1]) {
@@ -68,19 +192,20 @@ int damerau_levenshtein_distance(const JFISH_UNICODE *s1, const JFISH_UNICODE *s
             dist[((i+1)*cols) + j + 1] = MIN(MIN(d1, d2), MIN(d3, d4));
         }
 
-        da_idx = (JFISH_UNICODE)s1[i-1];
-        if (da_idx >= len_da) {
-            free(dist);
-            free(da);
-            return -2;
-        }
-        da[da_idx] = i;
+        if (!trie_set(da, s1[i-1], i)) {
+            result = -1;
+            goto cleanup;
+        };
     }
 
     result = dist[((len1+1) * cols) + len2 + 1];
 
+
+ cleanup:
     free(dist);
-    free(da);
+
+ cleanup_da:
+    trie_destroy(da);
 
     return result;
 }

--- a/jellyfishmodule.c
+++ b/jellyfishmodule.c
@@ -16,8 +16,6 @@ struct jellyfish_state {
 #define INLINE inline
 #endif
 
-#define UNSUPPORTED_CODEPOINT "Encountered unsupported code point in string."
-
 
 /* Returns a new reference to a PyString (python < 3) or
  * PyBytes (python >= 3.0).
@@ -144,11 +142,6 @@ static PyObject* jellyfish_damerau_levenshtein_distance(PyObject *self,
         PyErr_NoMemory();
         return NULL;
     }
-    else if (result == -2) {
-        PyErr_SetString(PyExc_ValueError, UNSUPPORTED_CODEPOINT);
-        return NULL;
-    }
-
     return Py_BuildValue("i", result);
 }
 


### PR DESCRIPTION
This PR adds support for non-ASCII codepoints for damerau_levenshtein_distance.

This is done by adding a trie data structure used as dictionary to store information for unicode characters.

It has the following properties:

- if no value is stored in the trie for a certain key, the lookup returns 0
- child nodes are created only when a new value must be stored in them
- upper digits that contain zeroes are ignored, so for ascii-only characters no child nodes are created and neighbouring characters on unicode planes are generally stored together