### PR TITLE
fix incorrect min_len

### DIFF
--- a/jaro.c
+++ b/jaro.c
@@ -111,7 +111,7 @@ double _jaro_winkler(const JFISH_UNICODE *ying, int ying_length,
     weight /=  3.0;
 
     // Continue to boost the weight if the strings are similar
-    if (winklerize && weight > 0.7 && ying_length > 3 && yang_length > 3) {
+    if (winklerize && weight > 0.7) {
 
         // Adjust for having up to the first 4 characters in common
         j = (min_len >= 4) ? 4 : min_len;

--- a/jaro.c
+++ b/jaro.c
@@ -40,8 +40,14 @@ double _jaro_winkler(const JFISH_UNICODE *ying, int ying_length,
     // ensure that neither string is blank
     if (!ying_length || !yang_length) return 0;
 
-    search_range = min_len = (ying_length > yang_length) ? ying_length : yang_length;
-
+    if (ying_length > yang_length) {
+        search_range = ying_length;
+        min_len = yang_length;
+    } else {
+        search_range = yang_length;
+        min_len = ying_length;
+    }
+  
     // Blank out the flags
     ying_flag = calloc((ying_length + 1), sizeof(JFISH_UNICODE));
     if (!ying_flag) {


### PR DESCRIPTION
This change is taken from the original implementation: https://web.archive.org/web/20100227020019/http://www.census.gov/geo/msb/stand/strcmp.c

Currently both search_range and min_len are set to the max_len. This is correct for the search_range, but not for the min_len.