### PR TITLE
catch multiplication overflows in allocations

### DIFF
--- a/damerau_levenshtein.c
+++ b/damerau_levenshtein.c
@@ -154,7 +154,7 @@ int damerau_levenshtein_distance(const JFISH_UNICODE *s1, const JFISH_UNICODE *s
         return -1;
     }
 
-    dist = malloc((len1 + 2) * cols * sizeof(size_t));
+    dist = safe_matrix_malloc((len1 + 2), cols, sizeof(size_t));
     if (!dist) {
         result = -1;
         goto cleanup_da;

--- a/jellyfish.h
+++ b/jellyfish.h
@@ -12,6 +12,26 @@
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #endif
 
+static inline void* safe_malloc(size_t num, size_t size)
+{
+    size_t alloc_size = num * size;
+    if (alloc_size / num != size)
+    {
+        return NULL;
+    }
+    return malloc(alloc_size);
+}
+
+static inline void* safe_matrix_malloc(size_t rows, size_t cols, size_t size)
+{
+    size_t matrix_size = rows * cols;
+    if (matrix_size / rows != cols)
+    {
+        return NULL;
+    }
+    return safe_malloc(matrix_size, size);
+}
+
 double jaro_winkler_similarity(const JFISH_UNICODE *str1, int len1, const JFISH_UNICODE *str2, int len2, int long_tolerance);
 double jaro_similarity(const JFISH_UNICODE *str1, int len1, const JFISH_UNICODE *str2, int len2);
 

--- a/jellyfishmodule.c
+++ b/jellyfishmodule.c
@@ -303,7 +303,7 @@ static PyObject* jellyfish_porter_stem(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    result = malloc((len+1) * sizeof(Py_UNICODE));
+    result = safe_malloc((len+1), sizeof(Py_UNICODE));
     if (!result) {
         free_stemmer(z);
         PyErr_NoMemory();

--- a/levenshtein.c
+++ b/levenshtein.c
@@ -11,7 +11,7 @@ int levenshtein_distance(const JFISH_UNICODE *s1, int s1_len, const JFISH_UNICOD
 
     unsigned result;
     unsigned d1, d2, d3;
-    unsigned *dist = malloc(rows * cols * sizeof(unsigned));
+    unsigned *dist = safe_matrix_malloc(rows, cols, sizeof(unsigned));
     if (!dist) {
         return -1;
     }

--- a/nysiis.c
+++ b/nysiis.c
@@ -11,7 +11,7 @@ JFISH_UNICODE *nysiis(const JFISH_UNICODE *str, int len) {
     JFISH_UNICODE *code = NULL;
     JFISH_UNICODE *p, *cp;
 
-    copy = malloc((len + 1) * sizeof(JFISH_UNICODE));
+    copy = safe_malloc((len+1), sizeof(JFISH_UNICODE));
     if (!copy) {
         return NULL;
     }


### PR DESCRIPTION
This should fix all places where depending on the input a overflow could occur when calculating the buffer size to allocate using malloc. As commented by @nijel here: https://github.com/jamesturk/jellyfish/issues/120 this can cause the implementation to allocate a smaller buffer than expected which is accessed out of bounds.
In the most recent clang and gcc releases this directly checks the overflow flag set by the multiplication, which makes this very fast