### PR TITLE
Handle spaces correctly in MRA algorithm; matches jellyfish PR #158

### DIFF
--- a/mra.c
+++ b/mra.c
@@ -88,6 +88,10 @@ JFISH_UNICODE* match_rating_codex(const JFISH_UNICODE *str, size_t len) {
     return codex;
 }
 
+static int is_vowel(JFISH_UNICODE c) {
+    return c == 'A' || c == 'E' || c == 'I' || c == 'O' || c == 'U';
+}
+
 static size_t compute_match_rating_codex(const JFISH_UNICODE *str, size_t len, JFISH_UNICODE codex[7]) {
     size_t i, j;
     JFISH_UNICODE c, prev;
@@ -96,22 +100,15 @@ static size_t compute_match_rating_codex(const JFISH_UNICODE *str, size_t len, J
     for(i = 0, j = 0; i < len && j < 7; i++) {
         c = toupper(str[i]);
 
-        if (c == ' ' || (i != 0 && (c == 'A' || c == 'E' || c == 'I' ||
-                                    c == 'O' || c == 'U'))) {
-            continue;
-        }
+        if ((c != ' ' && i == 0 && is_vowel(c)) || (!is_vowel(c) && c != prev)) {
+            if (j == 6) {
+                codex[3] = codex[4];
+                codex[4] = codex[5];
+                j = 5;
+            }
 
-        if (c == prev) {
-            continue;
+            codex[j++] = c;
         }
-
-        if (j == 6) {
-            codex[3] = codex[4];
-            codex[4] = codex[5];
-            j = 5;
-        }
-
-        codex[j++] = c;
         prev = c;
     }
 

--- a/mra.c
+++ b/mra.c
@@ -2,6 +2,12 @@
 #include <string.h>
 #include <ctype.h>
 
+#define ISVOWEL(c) ((c) == 'A' || (c) == 'E' || (c) == 'I' || \
+                    (c) == 'O' || (c) == 'U')
+
+#define TRUE 1
+#define FALSE 0
+
 static size_t compute_match_rating_codex(const JFISH_UNICODE *str, size_t len, JFISH_UNICODE codex[7]);
 
 int match_rating_comparison(const JFISH_UNICODE *s1, size_t len1, const JFISH_UNICODE *s2, size_t len2) {
@@ -89,13 +95,6 @@ JFISH_UNICODE* match_rating_codex(const JFISH_UNICODE *str, size_t len) {
     return codex;
 }
 
-static int is_vowel(JFISH_UNICODE c) {
-    return c == 'A' || c == 'E' || c == 'I' || c == 'O' || c == 'U';
-}
-
-#define TRUE 1
-#define FALSE 0
-
 static size_t compute_match_rating_codex(const JFISH_UNICODE *str, size_t len, JFISH_UNICODE codex[7]) {
     /* str is already in uppercase when this function is called */
     size_t i, j;
@@ -111,7 +110,7 @@ static size_t compute_match_rating_codex(const JFISH_UNICODE *str, size_t len, J
             continue;
         }
 
-        if (first || (!is_vowel(c) && c != prev)) {
+        if (first || (!ISVOWEL(c) && c != prev)) {
             if (j == 6) {
                 codex[3] = codex[4];
                 codex[4] = codex[5];

--- a/mra.c
+++ b/mra.c
@@ -92,15 +92,21 @@ static int is_vowel(JFISH_UNICODE c) {
     return c == 'A' || c == 'E' || c == 'I' || c == 'O' || c == 'U';
 }
 
+#define TRUE 1
+#define FALSE 0
+
 static size_t compute_match_rating_codex(const JFISH_UNICODE *str, size_t len, JFISH_UNICODE codex[7]) {
     size_t i, j;
+    int first;
     JFISH_UNICODE c, prev;
 
     prev = '\0';
+    first = TRUE;
     for(i = 0, j = 0; i < len && j < 7; i++) {
+        if (c == ' ') continue;
         c = toupper(str[i]);
 
-        if ((c != ' ' && i == 0 && is_vowel(c)) || (!is_vowel(c) && c != prev)) {
+        if (first || (!is_vowel(c) && c != prev)) {
             if (j == 6) {
                 codex[3] = codex[4];
                 codex[4] = codex[5];
@@ -110,6 +116,7 @@ static size_t compute_match_rating_codex(const JFISH_UNICODE *str, size_t len, J
             codex[j++] = c;
         }
         prev = c;
+        first = FALSE;
     }
 
     codex[j] = '\0';

--- a/mra.c
+++ b/mra.c
@@ -5,6 +5,7 @@
 static size_t compute_match_rating_codex(const JFISH_UNICODE *str, size_t len, JFISH_UNICODE codex[7]);
 
 int match_rating_comparison(const JFISH_UNICODE *s1, size_t len1, const JFISH_UNICODE *s2, size_t len2) {
+    /* s1 and s2 are already in uppercase when this function is called */
     size_t s1c_len, s2c_len;
     size_t i, j;
     int diff;
@@ -96,6 +97,7 @@ static int is_vowel(JFISH_UNICODE c) {
 #define FALSE 0
 
 static size_t compute_match_rating_codex(const JFISH_UNICODE *str, size_t len, JFISH_UNICODE codex[7]) {
+    /* str is already in uppercase when this function is called */
     size_t i, j;
     int first;
     JFISH_UNICODE c, prev;
@@ -103,8 +105,11 @@ static size_t compute_match_rating_codex(const JFISH_UNICODE *str, size_t len, J
     prev = '\0';
     first = TRUE;
     for(i = 0, j = 0; i < len && j < 7; i++) {
-        if (c == ' ') continue;
-        c = toupper(str[i]);
+        c = str[i];
+        if (!Py_UNICODE_ISALPHA(c)) {
+            prev = c;
+            continue;
+        }
 
         if (first || (!is_vowel(c) && c != prev)) {
             if (j == 6) {


### PR DESCRIPTION
This matches the pure Python implementation of https://github.com/jamesturk/jellyfish/pull/158 in `cjellyfish`.  It also incorporates the patch in PR #15 (which in turn fixes https://github.com/jamesturk/jellyfish/issues/155), so this patch would supersede that PR.