### PR TITLE
Remove Python-specific function from mra.c

### DIFF
--- a/jellyfish.h
+++ b/jellyfish.h
@@ -6,6 +6,12 @@
 #if CJELLYFISH_PYTHON
 #include <Python.h>
 #define JFISH_UNICODE Py_UCS4
+#define ISALPHA Py_UNICODE_ISALPHA
+#else
+#include <wctype.h>
+#include <wchar.h>
+#define JFISH_UNICODE wint_t
+#define ISALPHA iswalpha
 #endif
 
 #ifndef MIN

--- a/mra.c
+++ b/mra.c
@@ -105,7 +105,7 @@ static size_t compute_match_rating_codex(const JFISH_UNICODE *str, size_t len, J
     first = TRUE;
     for(i = 0, j = 0; i < len && j < 7; i++) {
         c = str[i];
-        if (!Py_UNICODE_ISALPHA(c)) {
+        if (!ISALPHA(c)) {
             prev = c;
             continue;
         }


### PR DESCRIPTION
Looking at the code a little longer, I realised that my comment on `JFISH_UNICODE` was not quite correct; you have very carefully restrained all Python dependencies to `jellyfishmodule.c`, and I broke that by putting a Python-specific function in `mra.c`. I have fixed that (I hope) in this PR.